### PR TITLE
add support for custom table name when adding id column

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -37,7 +37,7 @@ KnexStorage.prototype.history = async function () {
 
     // Add the missing primary key for older setups
     if (events.length && events[0].id === undefined) {
-      await this.knex.raw('ALTER TABLE migrations ADD COLUMN id SERIAL PRIMARY KEY;')
+      await this.knex.raw(`ALTER TABLE ${this.tableName} ADD COLUMN id SERIAL PRIMARY KEY;`)
     }
 
     return events


### PR DESCRIPTION
Today the alter table SQL added on [v4.0.0](https://github.com/marcbachmann/knex-umzug/releases/tag/v4.0.0) does not take into consideration the use of custom tableName.

This MR adds the support for the ALTER TABLE to be done on the correct table name, in case of a name different from `migrations`